### PR TITLE
works with a consitent version of ch hit now. 4.6

### DIFF
--- a/pycits/cd_hit.py
+++ b/pycits/cd_hit.py
@@ -20,7 +20,7 @@ from .tools import is_exe, NotExecutableError
 
 # factory class for cd_hit class returned values
 Results = namedtuple("Results", "command fastaout clusters " +
-                     "backcluster stdout stderr")
+                     "stdout stderr")
 
 
 class Cd_hit_Error(Exception):
@@ -59,6 +59,7 @@ class Cd_hit(object):
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               check=True)
+
         results = Results(self._cmd, *self._outfnames, pipe.stdout,
                           pipe.stderr)
         return results
@@ -86,8 +87,8 @@ class Cd_hit(object):
         """
         # outfiles are name WhatEver.out + .bak.clstr and + .clstr
         self._outfnames = [os.path.join(outdir, prefix) + suffix for suffix in
-                           ('', '.clstr', '.bak.clstr')]
-        cmd = ["cd_hit_est",
+                           ('.fasta', '.clstr')]
+        cmd = ["cd-hit-est",
                "-i", fasta_in,
                "-o", os.path.join(outdir, prefix),
                "-T {0}".format(threads),

--- a/tests/test_wrapper_cd_hit.py
+++ b/tests/test_wrapper_cd_hit.py
@@ -30,7 +30,7 @@ def test_cd_hit():
 def test_cd_hit_cmd():
     """cd_hit instantiates and returns correct form of cmd-line"""
     cluster = cd_hit.Cd_hit("cd-hit-est")
-    target = ' '.join(["cd_hit_est",
+    target = ' '.join(["cd-hit-est",
                        "-i", INFILE,
                        "-o", os.path.join(OUTDIR, PREFIX),
                        "-T", "4",


### PR DESCRIPTION
error was: under testing different versions were calling different versions of cd-hit. The new version 4.6 - the one recommended did not produce a .bak.clustr file. 